### PR TITLE
feat: [Tier 3] Unit tests for joke service, plugin, and orchestrator (#5)

### DIFF
--- a/src/Imeritas.Agent.DadJokes.CLI.Tests/DadJokeOrchestratorTests.cs
+++ b/src/Imeritas.Agent.DadJokes.CLI.Tests/DadJokeOrchestratorTests.cs
@@ -1,0 +1,87 @@
+using Imeritas.Agent.DadJokes.CLI.Orchestrator;
+using Imeritas.Agent.DadJokes.CLI.Services;
+using Imeritas.Agent.Models;
+using Imeritas.Agent.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Imeritas.Agent.DadJokes.CLI.Tests;
+
+public class DadJokeOrchestratorTests
+{
+    private readonly DadJokeOrchestrator _orchestrator;
+    private readonly IStorageService _storage;
+
+    public DadJokeOrchestratorTests()
+    {
+        _storage = Substitute.For<IStorageService>();
+        _storage.SaveTaskAsync(Arg.Any<string>(), Arg.Any<AgentTask>()).Returns(Task.CompletedTask);
+        var logger = NullLogger<DadJokeOrchestrator>.Instance;
+        _orchestrator = new DadJokeOrchestrator(_storage, logger);
+    }
+
+    [Fact]
+    public void CanHandle_DadJokeTaskType_ReturnsTrue()
+    {
+        Assert.True(_orchestrator.CanHandle("t1", "dad_joke", "tell me a joke"));
+    }
+
+    [Fact]
+    public void CanHandle_OtherTaskType_ReturnsFalse()
+    {
+        Assert.False(_orchestrator.CanHandle("t1", "email", "send email"));
+    }
+
+    [Fact]
+    public void CanHandle_NullTaskType_ReturnsFalse()
+    {
+        Assert.False(_orchestrator.CanHandle("t1", null, "tell me a joke"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsCompletedTaskWithJoke()
+    {
+        var result = await _orchestrator.ExecuteAsync("t1", "u1", "tell me a joke");
+
+        Assert.Equal(Imeritas.Agent.Models.TaskStatus.Completed, result.Status);
+        Assert.True(result.OutputData.ContainsKey("result"));
+        Assert.NotEmpty(result.OutputData["result"]?.ToString()!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesCategoryFromInputData()
+    {
+        var category = JokeRepository.GetAllCategories()[0];
+        var inputData = new Dictionary<string, object> { ["category"] = category };
+
+        var result = await _orchestrator.ExecuteAsync("t1", "u1", "tell me a joke",
+            inputData: inputData);
+
+        Assert.Equal(Imeritas.Agent.Models.TaskStatus.Completed, result.Status);
+        Assert.NotEmpty(result.OutputData["result"]?.ToString()!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FallsBackToRandomWhenCategoryNotFound()
+    {
+        var inputData = new Dictionary<string, object> { ["category"] = "nonexistent_xyz" };
+
+        var result = await _orchestrator.ExecuteAsync("t1", "u1", "tell me a joke",
+            inputData: inputData);
+
+        Assert.Equal(Imeritas.Agent.Models.TaskStatus.Completed, result.Status);
+        Assert.NotEmpty(result.OutputData["result"]?.ToString()!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MapsQueueTaskIdFromInputData()
+    {
+        var inputData = new Dictionary<string, object> { ["_queue_task_id"] = "queue-123" };
+
+        var result = await _orchestrator.ExecuteAsync("t1", "u1", "tell me a joke",
+            inputData: inputData);
+
+        Assert.Equal("queue-123", result.TaskId);
+    }
+}

--- a/src/Imeritas.Agent.DadJokes.CLI.Tests/DadJokesPluginTests.cs
+++ b/src/Imeritas.Agent.DadJokes.CLI.Tests/DadJokesPluginTests.cs
@@ -1,0 +1,84 @@
+using Imeritas.Agent.DadJokes.CLI.Plugin;
+using Imeritas.Agent.DadJokes.CLI.Services;
+using Imeritas.Agent.Extensions;
+using Imeritas.Agent.Models;
+using Imeritas.Agent.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Imeritas.Agent.DadJokes.CLI.Tests;
+
+public class DadJokesPluginTests
+{
+    private readonly DadJokesPlugin _plugin;
+
+    public DadJokesPluginTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.ResolveTenantId().Returns("test-tenant");
+        tenantContext.GetTenantConfigAsync("test-tenant").Returns(Task.FromResult(new TenantConfig
+        {
+            TenantId = "test-tenant",
+            Name = "Test",
+            Plugins = new Dictionary<string, PluginTenantConfig>()
+        }));
+
+        var loggerFactory = NullLoggerFactory.Instance;
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var configuration = new ConfigurationBuilder().Build();
+
+        var host = new PluginHostContext(tenantContext, loggerFactory, httpClientFactory, configuration);
+        _plugin = new DadJokesPlugin(host);
+    }
+
+    [Fact]
+    public void TellJoke_ValidCategory_ReturnsFormattedJokeString()
+    {
+        var category = JokeRepository.GetAllCategories()[0];
+
+        var result = _plugin.TellJoke(category);
+
+        Assert.NotEmpty(result);
+        Assert.Contains("\n", result);
+    }
+
+    [Fact]
+    public void TellJoke_NullCategory_ReturnsRandomJoke()
+    {
+        var result = _plugin.TellJoke(null);
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void TellJoke_UnmatchedCategory_ReturnsRandomJoke()
+    {
+        var result = _plugin.TellJoke("nonexistent_xyz_category");
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void Plugin_NameDisplayNameDescription_AreCorrect()
+    {
+        Assert.Equal("DadJokes", _plugin.Name);
+        Assert.NotEmpty(_plugin.DisplayName);
+        Assert.NotEmpty(_plugin.Description);
+    }
+
+    [Fact]
+    public void DirectlyInvocableFunctions_IncludesTellJoke()
+    {
+        Assert.Contains("tell_joke", _plugin.DirectlyInvocableFunctions);
+    }
+
+    [Fact]
+    public void SlashCommands_IncludesJokeCommand()
+    {
+        var contributor = (IClassificationContributor)_plugin;
+
+        Assert.Contains(contributor.SlashCommands, c => c.Command == "/joke");
+    }
+}

--- a/src/Imeritas.Agent.DadJokes.CLI.Tests/JokeRepositoryTests.cs
+++ b/src/Imeritas.Agent.DadJokes.CLI.Tests/JokeRepositoryTests.cs
@@ -1,0 +1,74 @@
+using Imeritas.Agent.DadJokes.CLI.Models;
+using Imeritas.Agent.DadJokes.CLI.Services;
+using Xunit;
+
+namespace Imeritas.Agent.DadJokes.CLI.Tests;
+
+public class JokeRepositoryTests
+{
+    [Fact]
+    public void GetByCategory_ValidCategory_ReturnsMatchingJokes()
+    {
+        var categories = JokeRepository.GetAllCategories();
+        var category = categories[0];
+
+        var results = JokeRepository.GetByCategory(category);
+
+        Assert.NotEmpty(results);
+        Assert.All(results, joke =>
+            Assert.Contains(joke.Categories, c =>
+                string.Equals(c, category, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void GetByCategory_UnknownCategory_ReturnsEmpty()
+    {
+        var results = JokeRepository.GetByCategory("nonexistent_xyz_category");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void GetByCategory_IsCaseInsensitive()
+    {
+        var categories = JokeRepository.GetAllCategories();
+        var category = categories[0];
+
+        var results = JokeRepository.GetByCategory(category.ToUpperInvariant());
+
+        Assert.NotEmpty(results);
+    }
+
+    [Fact]
+    public void GetRandom_ReturnsNonNullJoke()
+    {
+        var joke = JokeRepository.GetRandom();
+
+        Assert.NotNull(joke);
+        Assert.NotEmpty(joke.Setup);
+        Assert.NotEmpty(joke.Punchline);
+    }
+
+    [Fact]
+    public void GetAllCategories_ReturnsSortedDistinctCategories()
+    {
+        var categories = JokeRepository.GetAllCategories();
+
+        Assert.True(categories.Count >= 2);
+        Assert.Equal(
+            categories.OrderBy(c => c, StringComparer.OrdinalIgnoreCase).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            categories);
+    }
+
+    [Fact]
+    public void Collection_ContainsAtLeast20Jokes()
+    {
+        var categories = JokeRepository.GetAllCategories();
+        var allJokes = categories
+            .SelectMany(c => JokeRepository.GetByCategory(c))
+            .DistinctBy(j => j.Id)
+            .ToList();
+
+        Assert.True(allJokes.Count >= 20);
+    }
+}


### PR DESCRIPTION
## Summary

Automated implementation for #5.

All done. **19 tests passing, 0 warnings, 0 errors.**

Summary of what was created:

| File | Tests | Coverage |
|---|---|---|
| `JokeRepositoryTests.cs` | 6 | Category lookup, case insensitivity, random selection, sorted categories, 20+ joke minimum |
| `DadJokesPluginTests.cs` | 6 | TellJoke with valid/null/unknown category, plugin identity, DirectlyInvocableFunctions, SlashCommands |
| `DadJokeOrchestratorTests.cs` | 7 | CanHandle routing (dad_joke/other/null), ExecuteAsync happy path, category routing, fallback to random, queue task ID mapping |

Key adaptations from the plan to match actual source code:
- `TellJoke` is synchronous (`string`), not `async Task<string>`
- Orchestrator `Name` is `"DadJokeOrchestrator"` (not `"DadJoke"`)
- `CanHandle` uses exact `==` comparison (not case-insensitive)
- `_storage.SaveTaskAsync` mock configured since it's called in the `finally` block

Closes #5

---
*Generated by Imeritas.Agent delivery workflow.*