### PR TITLE
feat: [Tier 3] Build validation and solution-level integration (#6)

### DIFF
--- a/src/Imeritas.Agent.DadJokes.CLI/Imeritas.Agent.DadJokes.CLI.csproj
+++ b/src/Imeritas.Agent.DadJokes.CLI/Imeritas.Agent.DadJokes.CLI.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Imeritas.Agent.Contracts" Version="*" />

--- a/src/Imeritas.Agent.DadJokes.CLI/Orchestrator/DadJokeOrchestrator.cs
+++ b/src/Imeritas.Agent.DadJokes.CLI/Orchestrator/DadJokeOrchestrator.cs
@@ -16,6 +16,11 @@ public class DadJokeOrchestrator : ITaskOrchestrator
     private readonly IStorageService _storage;
     private readonly ILogger<DadJokeOrchestrator> _logger;
 
+    /// <summary>
+    /// Initializes the DadJokeOrchestrator with storage and logging dependencies.
+    /// </summary>
+    /// <param name="storage">Storage service for persisting task state.</param>
+    /// <param name="logger">Logger instance for structured logging.</param>
     public DadJokeOrchestrator(
         IStorageService storage,
         ILogger<DadJokeOrchestrator> logger)


### PR DESCRIPTION
## Summary

Automated implementation for #6.

All done. Here's a summary of what was done:

**Changes made (2 files):**

1. **`Imeritas.Agent.DadJokes.CLI.csproj`** — Added `TreatWarningsAsErrors` and `GenerateDocumentationFile` to enforce strict build quality
2. **`DadJokeOrchestrator.cs`** — Added missing XML documentation on the public constructor (was the only CS1591 violation)

**Audit results (all passing, no changes needed):**
- All 8 `.cs` files use file-scoped namespaces
- No `#nullable disable` anywhere
- All public types/methods have XML docs (or `<inheritdoc />`)
- All logging uses `ILogger<T>` with message template placeholders
- No `Console.WriteLine` in production code
- No hardcoded secrets or external URLs
- Plugin kernel functions use try-catch and return error strings
- Orchestrator uses try-catch with `TaskStatus.Failed` on error
- Tests use NSubstitute (not Moq)
- Test naming follows `{Method}_{Scenario}_{Expected}` convention

**Final validation:**
- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 19 passed, 0 failed

Closes #6

---
*Generated by Imeritas.Agent delivery workflow.*